### PR TITLE
Lambda を Docker(ECR) から zip(provided.al2) へ移行

### DIFF
--- a/.github/workflows/serverless-dev.yml
+++ b/.github/workflows/serverless-dev.yml
@@ -30,6 +30,9 @@ jobs:
           role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
           aws-region: ap-northeast-1
 
+      - name: install plugins
+        run: npm install
+
       - name: deploy
         run: sls deploy --stage dev
         env:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,22 @@
-FROM crystallang/crystal:latest as build-image
-
-WORKDIR /work
-COPY ./ ./
-
-RUN crystal build --link-flags -static -o bootstrap src/main.cr
-RUN chmod +x bootstrap
-
-FROM public.ecr.aws/lambda/provided:latest
-
-COPY --from=build-image /work/bootstrap /var/runtime/
-
-CMD ["dummyHandler"]
+# =====================================================================
+# Docker(ECR イメージ)版の Dockerfile【旧構成・参考用にコメントアウト】
+# ---------------------------------------------------------------------
+# zip(provided.al2)版へ移行したため未使用。
+# zip 版では serverless.yml の scripts フックが crystallang/crystal イメージで
+# `crystal build --link-flags -static -o bootstrap src/main.cr` を実行して
+# bootstrap を生成するため、この Dockerfile は不要になった。
+# ---------------------------------------------------------------------
+# FROM crystallang/crystal:latest as build-image
+#
+# WORKDIR /work
+# COPY ./ ./
+#
+# RUN crystal build --link-flags -static -o bootstrap src/main.cr
+# RUN chmod +x bootstrap
+#
+# FROM public.ecr.aws/lambda/provided:latest
+#
+# COPY --from=build-image /work/bootstrap /var/runtime/
+#
+# CMD ["dummyHandler"]
+# =====================================================================

--- a/README.md
+++ b/README.md
@@ -5,5 +5,3 @@
 
 ### 参考にした
   - https://www.m3tech.blog/entry/aws-lambda-custom-runtime
-
-## GAテスト用コミット

--- a/README.md
+++ b/README.md
@@ -5,3 +5,5 @@
 
 ### 参考にした
   - https://www.m3tech.blog/entry/aws-lambda-custom-runtime
+
+## GAテスト用コミット

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,22 @@
+{
+  "name": "lambda-crystal-sls",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "lambda-crystal-sls",
+      "version": "0.1.0",
+      "devDependencies": {
+        "serverless-plugin-scripts": "^1.0.2"
+      }
+    },
+    "node_modules/serverless-plugin-scripts": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/serverless-plugin-scripts/-/serverless-plugin-scripts-1.0.2.tgz",
+      "integrity": "sha512-+OL9fFz5r6BXNHfpu9MDLehS/haC0fy/T3V5uJsTfLAnNsn+PzM6BmvefUfWG372hBT7piTbywB1Vl1+4LmI5Q==",
+      "dev": true,
+      "license": "MIT"
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "lambda-crystal-sls",
+  "version": "0.1.0",
+  "private": true,
+  "devDependencies": {
+    "serverless-plugin-scripts": "^1.0.2"
+  }
+}

--- a/serverless.yml
+++ b/serverless.yml
@@ -1,40 +1,94 @@
 service: lambda-crystal-sls
 
+plugins:
+  - serverless-plugin-scripts
+
 custom:
-  defaultAccount: dummy
-  defaultDigest: dummy
   defaultStage: dev
+  scripts:
+    hooks:
+      # sls deploy / sls package 時に bootstrap を静的ビルドする。
+      # macOS / Apple Silicon でも Lambda(provided.al2, x86_64) 互換の
+      # 静的バイナリを得るため、linux/amd64 を明示して Docker でビルドする。
+      # chmod はコンテナ内(root)で実行する。Linux ランナーでは生成物が
+      # root 所有になり、コンテナ外の runner ユーザーでは chmod できないため。
+      'before:package:createDeploymentArtifacts': |
+        docker run --rm --platform linux/amd64 -v "$PWD":/work -w /work crystallang/crystal:latest \
+          sh -c "crystal build --link-flags -static -o bootstrap src/main.cr && chmod +x bootstrap"
 
 provider:
   name: aws
-  runtime: provided
+  runtime: provided.al2
   timeout: 20
   region: ap-northeast-1
-  ecr:
-    images:
-      appImage:
-        path: ./
-        platform: linux/amd64
   stage: ${opt:stage, self:custom.defaultStage}
   # environment:
   #   ${file(./env.yml)}
 
+package:
+  patterns:
+    - '!./**'
+    - bootstrap
+
 functions:
+  # provided ランタイムはパッケージ直下の bootstrap を実行する。
+  # handler 文字列は _HANDLER として渡され、src/main.cr の
+  # Serverless::Lambda.handler "..." と一致させることで処理を振り分ける。
   hello:
-    image:
-      name: appImage
-      command:
-        - hello
+    handler: hello
     events:
       - http:
           path: test
           method: get
   world:
-    image:
-      name: appImage
-      command:
-        - world
+    handler: world
     events:
       - http:
           path: test
           method: post
+
+# =====================================================================
+# Docker(ECR イメージ)版【旧構成・参考用にコメントアウトで残す】
+# ---------------------------------------------------------------------
+# Dockerfile から ECR イメージをビルドし、image.command で各関数の
+# _HANDLER を切り替えていた。zip 版へ移行したため無効化。
+# ---------------------------------------------------------------------
+# custom:
+#   defaultAccount: dummy
+#   defaultDigest: dummy
+#   defaultStage: dev
+#
+# provider:
+#   name: aws
+#   runtime: provided
+#   timeout: 20
+#   region: ap-northeast-1
+#   ecr:
+#     images:
+#       appImage:
+#         path: ./
+#         platform: linux/amd64
+#   stage: ${opt:stage, self:custom.defaultStage}
+#   # environment:
+#   #   ${file(./env.yml)}
+#
+# functions:
+#   hello:
+#     image:
+#       name: appImage
+#       command:
+#         - hello
+#     events:
+#       - http:
+#           path: test
+#           method: get
+#   world:
+#     image:
+#       name: appImage
+#       command:
+#         - world
+#     events:
+#       - http:
+#           path: test
+#           method: post
+# =====================================================================

--- a/src/runtime/lambda.cr
+++ b/src/runtime/lambda.cr
@@ -5,7 +5,7 @@ module Serverless
   module Lambda
     extend self
 
-    def handler(name : String)
+    def handler(name : String, &)
       return if name != ENV["_HANDLER"]
 
       ENV["SSL_CERT_FILE"] = "/etc/pki/tls/cert.pem"


### PR DESCRIPTION
## 概要
このサンプル実装の Lambda デプロイ方式を、Docker(ECR イメージ)から zip(`provided.al2`)へ移行しました。サンプルとしての参照価値のため、Docker 版のコードはコメントアウトで残しています。

参考: https://github.com/limit7412/github_notifications_slack

## 変更内容
- **serverless.yml**: `serverless-plugin-scripts` の `before:package:createDeploymentArtifacts` フックで `crystallang/crystal`(`--platform linux/amd64`)による静的 `bootstrap` ビルドを行う zip 構成に変更。`package.patterns` で `bootstrap` のみをパッケージング。`hello` / `world` は単一の `bootstrap` を共有し、`handler` 文字列(`_HANDLER`)で振り分け。旧 ECR image 構成はコメントで保存。
- **Dockerfile**: zip 版では不要のため全体をコメントアウト(参考用に保持)。
- **package.json / package-lock.json**: `serverless-plugin-scripts` を追加。
- **src/runtime/lambda.cr**: `handler` に明示的なブロック引数(`&`)を付与し、新しい Crystal の yield メソッド構文に対応。

## 動作確認
旧 Docker スタックを `sls remove` 後、zip 版を `sls deploy --stage dev` し、両エンドポイントで 200 を確認。
- `GET /dev/test` (hello) → `200` / `{"msg":"さよなら透明だった僕たち"}`
- `POST /dev/test` (world) → `200` / `{"msg":"でしょうねミスター・サーバーレス","event":{...}}`

🤖 Generated with [Claude Code](https://claude.com/claude-code)