### PR TITLE
fix: musl(Alpine)で静的ビルドし外部HTTPS通信を復旧

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -12,9 +12,15 @@ custom:
       # 静的バイナリを得るため、linux/arm64 を明示して Docker でビルドする。
       # chmod はコンテナ内(root)で実行する。Linux ランナーでは生成物が
       # root 所有になり、コンテナ外の runner ユーザーでは chmod できないため。
+      #
+      # glibc で静的リンクしたバイナリは provided.al2023 上で外部 HTTPS 通信に
+      # 失敗する(OpenSSL の初期化エラー)ため、api.github.com / hooks.slack.com
+      # へ到達できない。musl(Alpine)ベースで静的リンクすると外部通信が復旧する。
+      # 併せて静的リンクに必要なライブラリ(OpenSSL / zlib / libevent)を
+      # apk add --no-cache で明示導入し、ベースイメージ更新時のリンク失敗を防ぐ。
       'before:package:createDeploymentArtifacts': |
-        docker run --rm --platform linux/arm64 -v "$PWD":/work -w /work crystallang/crystal:latest \
-          sh -c "crystal build --link-flags -static -o bootstrap src/main.cr && chmod +x bootstrap"
+        docker run --rm --platform linux/arm64 -v "$PWD":/work -w /work crystallang/crystal:latest-alpine \
+          sh -c "apk add --no-cache openssl-libs-static zlib-static libevent-static && crystal build --link-flags -static -o bootstrap src/main.cr && chmod +x bootstrap"
 
 provider:
   name: aws


### PR DESCRIPTION
## 概要

本家 [github_notifications_slack#89](https://github.com/limit7412/github_notifications_slack/pull/89) の修正を本リポジトリ(Crystal 版)へ適用します。

## 背景・問題

- glibc で静的リンクしたバイナリは Lambda の `provided.al2023` ランタイム上で外部 HTTPS 通信に失敗する(OpenSSL の初期化エラー: `unregistered scheme`)。
- そのため `api.github.com` / `hooks.slack.com` へ到達できず、Slack 通知が届かない状態になっていた。

## 変更内容

`serverless.yml` のビルドフック(`before:package:createDeploymentArtifacts`)を変更:

- ビルドベースイメージを `crystallang/crystal:latest`(glibc)→ `crystallang/crystal:latest-alpine`(musl)へ切り替え。musl ベースの静的バイナリでは外部 HTTPS 通信が正常に動作する。
- 静的リンクに必要なライブラリ(`openssl-libs-static` / `zlib-static` / `libevent-static`)を `apk add --no-cache` で明示導入し、ベースイメージ更新時のリンク失敗を防止。

```diff
-        docker run --rm --platform linux/arm64 -v "$PWD":/work -w /work crystallang/crystal:latest \
-          sh -c "crystal build --link-flags -static -o bootstrap src/main.cr && chmod +x bootstrap"
+        docker run --rm --platform linux/arm64 -v "$PWD":/work -w /work crystallang/crystal:latest-alpine \
+          sh -c "apk add --no-cache openssl-libs-static zlib-static libevent-static && crystal build --link-flags -static -o bootstrap src/main.cr && chmod +x bootstrap"
```

あわせて、上記の理由を説明するコメントを `serverless.yml` に追記しています。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ncf7NZnj7J6EnqDBCBr7RD

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ncf7NZnj7J6EnqDBCBr7RD)_